### PR TITLE
Add meta data to task

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,10 +2,10 @@ PATH
   remote: .
   specs:
     proforma (0.7)
-      activemodel (>= 5.2.3, < 6.2.0)
-      activesupport (>= 5.2.3, < 6.2.0)
-      nokogiri (>= 1.10.2, < 1.13.0)
-      rubyzip (>= 1.2.2, < 2.4.0)
+      activemodel (>= 5.2.3, < 7.0.0)
+      activesupport (>= 5.2.3, < 7.0.0)
+      nokogiri (>= 1.10.2, < 2.0.0)
+      rubyzip (>= 1.2.2, < 3.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -49,9 +49,11 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     lumberjack (1.2.8)
     method_source (1.0.0)
+    mini_portile2 (2.6.1)
     minitest (5.14.4)
     nenv (0.3.0)
-    nokogiri (1.12.5-x86_64-linux)
+    nokogiri (1.12.5)
+      mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    proforma (0.6)
+    proforma (0.7)
       activemodel (>= 5.2.3, < 6.2.0)
       activesupport (>= 5.2.3, < 6.2.0)
       nokogiri (>= 1.10.2, < 1.13.0)
@@ -49,11 +49,9 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     lumberjack (1.2.8)
     method_source (1.0.0)
-    mini_portile2 (2.6.1)
     minitest (5.14.4)
     nenv (0.3.0)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.12.5-x86_64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
-    racc (1.5.2)
+    racc (1.6.0)
     rainbow (3.0.0)
     rake (13.0.6)
     rb-fsevent (0.11.0)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This gem offers a ruby implementation of https://github.com/ProFormA/proformaxml
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'proforma', git: 'git://github.com/openHPI/proforma.git', tag: 'v0.5'
+gem 'proforma', git: 'git://github.com/openHPI/proforma.git', tag: 'v0.7'
 ```
 
 And then execute:
@@ -52,6 +52,15 @@ Proforma::Task.new(
   description: 'description',
   internal_description: 'internal_description',
   proglang: {name: 'proglang_name', version: '123'},
+  meta_data: {
+    CodeOcean: {
+      meta_data_key: 'meta_data_content',
+      secrets: {
+        server_key: 'the key',
+        other_key: 'another key'
+      }
+    }
+  },
   files: [
     Proforma::TaskFile.new(
       id: 'file_id_1',
@@ -91,7 +100,11 @@ Proforma::Task.new(
           internal_description: 'internal_description',
         )
       ],
-      meta_data: [{ namespace: 'prefix', key: 'key', value: 'value' }]
+      meta_data: {
+        CodeOcean: {
+          entry_point: 'junit/assert123.java'
+        }
+      }
     )
   ],
   uuid: '2c8ee23e-fa98-4ea9-b6a5-9a0066ebac1f',
@@ -117,10 +130,10 @@ Proforma::Task.new(
 )
 
 ```
-Generated XML from task above with `custom_namespaces: [{prefix: 'prefix', uri: 'test.namespace'}]`
+Generated XML from task above with `custom_namespaces: [{prefix: 'CodeOcean', uri: 'codeocean.openhpi.de'}]`
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<task xmlns="urn:proforma:v2.0.1" xmlns:prefix="test.namespace" uuid="2c8ee23e-fa98-4ea9-b6a5-9a0066ebac1f" lang="de" parent-uuid="abf097f5-0df0-468d-8ce4-13460c34cd3b">
+<task xmlns="urn:proforma:v2.0.1" xmlns:CodeOcean="codeocean.openhpi.de" uuid="2c8ee23e-fa98-4ea9-b6a5-9a0066ebac1f" lang="de" parent-uuid="abf097f5-0df0-468d-8ce4-13460c34cd3b">
   <title>title</title>
   <description>description</description>
   <internal-description>internal_description</internal-description>
@@ -160,12 +173,18 @@ Generated XML from task above with `custom_namespaces: [{prefix: 'prefix', uri: 
           <fileref refid="test_file_1"/>
         </filerefs>
         <test-meta-data>
-          <prefix:key>value</prefix:key>
+          <CodeOcean:entry_point>junit/assert123.java</CodeOcean:entry_point>
         </test-meta-data>
       </test-configuration>
     </test>
   </tests>
-  <meta-data/>
+  <meta-data>
+    <CodeOcean:meta_data_key>meta_data_content</CodeOcean:meta_data_key>
+    <CodeOcean:secrets>
+      <CodeOcean:server_key>the key</CodeOcean:server_key>
+      <CodeOcean:other_key>another key</CodeOcean:other_key>
+    </CodeOcean:secrets>
+  </meta-data>
 </task>
 ```
 ## Development

--- a/bin/console
+++ b/bin/console
@@ -25,7 +25,7 @@ Pry.start
 #   uuid: SecureRandom.uuid,
 #   language: 'de',
 #   meta_data: {
-#     openHPI: {
+#     CodeOcean: {
 #       metao: 'datao',
 #       bla: 'bloo',
 #       secrets: {
@@ -73,19 +73,15 @@ Pry.start
 #         )
 #       ],
 #       meta_data: {
-#         openHPI: {
+#         CodeOcean: {
 #           meta: 'data'
 #         }
 #       }
-#       # meta_data: [
-#       #   { namespace: 'openHPI', key: 'meta', value: 'data' }
-#       # ]
 #     )
 #   ]
 # )
 
+# task = Proforma::Task.new(title: 't', description: 'd', internal_description:'id', proglang: { name: 'Ruby', version: '1' }, uuid: SecureRandom.uuid, language: 'de', meta_data: { CodeOcean: { metao: 'datao', bla: 'bloo', secrets: { server_key: 'asdf', other_key: 'fdsa' } } }, files: [Proforma::TaskFile.new(id: 'file1', content: 'c', used_by_grader: true, visible: 'yes', binary: false)], model_solutions: [Proforma::ModelSolution.new(id: 'ms1', description: 'd', internal_description:'id', files: [Proforma::TaskFile.new(id: 'ms-file1', content: 'ms-c', used_by_grader: true, visible: 'yes', binary: false)])], tests: [Proforma::Test.new(id: 'test1', test_type: 'type', files: [Proforma::TaskFile.new(id: 'testfile1', content: 'testc', used_by_grader: true, visible: 'yes', binary: false)], meta_data: { CodeOcean: { meta: 'data' } })])
 
-# task = Proforma::Task.new(title: 't', description: 'd', internal_description:'id', proglang: { name: 'Ruby', version: '1' }, uuid: SecureRandom.uuid, language: 'de', files: [Proforma::TaskFile.new(id: 'file1', content: 'c', used_by_grader: true, visible: 'yes', binary: false)], model_solutions: [Proforma::ModelSolution.new(id: 'ms1', description: 'd', internal_description:'id', files: [Proforma::TaskFile.new(id: 'ms-file1', content: 'ms-c', used_by_grader: true, visible: 'yes', binary: false)])], tests: [Proforma::Test.new(id: 'test1', test_type: 'type', files: [Proforma::TaskFile.new(id: 'testfile1', content: 'testc', used_by_grader: true, visible: 'yes', binary: false)], meta_data: [{ namespace: 'openHPI', key: 'meta', value: 'data' }])])
-
-# File.open('../testfiles/testfile.zip', 'wb') { |file| file.write(Proforma::Exporter.new(task: task, custom_namespaces: [{prefix: 'openHPI', uri: 'open.hpi.de'}]).perform.string) }
+# File.open('../testfiles/testfile.zip', 'wb') { |file| file.write(Proforma::Exporter.new(task: task, custom_namespaces: [{prefix: 'CodeOcean', uri: 'codeocean.openhpi.de'}]).perform.string) }
 #

--- a/bin/console
+++ b/bin/console
@@ -24,6 +24,16 @@ Pry.start
 #   proglang: { name: 'Ruby', version: '1' },
 #   uuid: SecureRandom.uuid,
 #   language: 'de',
+#   meta_data: {
+#     openHPI: {
+#       metao: 'datao',
+#       bla: 'bloo',
+#       secrets: {
+#         server_key: 'asdf',
+#         other_key: 'fdsa'
+#       }
+#     }
+#   },
 #   files: [
 #     Proforma::TaskFile.new(
 #       id: 'file1',
@@ -62,12 +72,20 @@ Pry.start
 #           binary: false
 #         )
 #       ],
-#       meta_data: [
-#         { namespace: 'openHPI', key: 'meta', value: 'data' }
-#       ]
+#       meta_data: {
+#         openHPI: {
+#           meta: 'data'
+#         }
+#       }
+#       # meta_data: [
+#       #   { namespace: 'openHPI', key: 'meta', value: 'data' }
+#       # ]
 #     )
 #   ]
 # )
+
+
+# task = Proforma::Task.new(title: 't', description: 'd', internal_description:'id', proglang: { name: 'Ruby', version: '1' }, uuid: SecureRandom.uuid, language: 'de', files: [Proforma::TaskFile.new(id: 'file1', content: 'c', used_by_grader: true, visible: 'yes', binary: false)], model_solutions: [Proforma::ModelSolution.new(id: 'ms1', description: 'd', internal_description:'id', files: [Proforma::TaskFile.new(id: 'ms-file1', content: 'ms-c', used_by_grader: true, visible: 'yes', binary: false)])], tests: [Proforma::Test.new(id: 'test1', test_type: 'type', files: [Proforma::TaskFile.new(id: 'testfile1', content: 'testc', used_by_grader: true, visible: 'yes', binary: false)], meta_data: [{ namespace: 'openHPI', key: 'meta', value: 'data' }])])
 
 # File.open('../testfiles/testfile.zip', 'wb') { |file| file.write(Proforma::Exporter.new(task: task, custom_namespaces: [{prefix: 'openHPI', uri: 'open.hpi.de'}]).perform.string) }
 #

--- a/lib/proforma/helpers/export_helpers.rb
+++ b/lib/proforma/helpers/export_helpers.rb
@@ -29,9 +29,33 @@ module Proforma
           add_unittest_configuration(xml, test)
           if test.meta_data
             xml.send('test-meta-data') do
-              # underscore is used to disambiguate tag names from ruby methods
-              test.meta_data.each { |entry| xml[entry[:namespace]].send("#{entry[:key]}_", entry[:value]) }
+              meta_data(xml, test.meta_data)
             end
+          end
+        end
+      end
+
+      def inner_meta_data(xml, namespace, _key, data)
+        data.each do |key, value|
+          xml[namespace].send("#{key}_", data[key]) if value.is_a? String
+
+          next unless value.is_a? Hash
+
+          xml[namespace].send("#{key}_") do |xml|
+            inner_meta_data(xml, namespace, key, value)
+          end
+        end
+      end
+
+      def meta_data(xml, meta_data)
+        # underscore is used to disambiguate tag names from ruby methods
+        meta_data.each do |namespace, data|
+          # if data.is_a? String
+          #   data
+          # end
+          data.each do |key, value|
+            xml[namespace].send("#{key}_", data[key]) if value.is_a? String
+            inner_meta_data(xml, namespace, key, value) if value.is_a? Hash
           end
         end
       end

--- a/lib/proforma/helpers/export_helpers.rb
+++ b/lib/proforma/helpers/export_helpers.rb
@@ -39,6 +39,7 @@ module Proforma
         data.each do |key, value|
           case value.class.name
           when 'Hash'
+            # underscore is used to disambiguate tag names from ruby methods
             xml[namespace].send("#{key}_") do |meta_data_xml|
               inner_meta_data(meta_data_xml, namespace, value)
             end
@@ -49,7 +50,6 @@ module Proforma
       end
 
       def meta_data(xml, meta_data)
-        # underscore is used to disambiguate tag names from ruby methods
         meta_data&.each do |namespace, data|
           inner_meta_data(xml, namespace, data)
         end

--- a/lib/proforma/helpers/export_helpers.rb
+++ b/lib/proforma/helpers/export_helpers.rb
@@ -41,8 +41,8 @@ module Proforma
 
           next unless value.is_a? Hash
 
-          xml[namespace].send("#{key}_") do |xml|
-            inner_meta_data(xml, namespace, key, value)
+          xml[namespace].send("#{key}_") do |meta_data_xml|
+            inner_meta_data(meta_data_xml, namespace, key, value)
           end
         end
       end

--- a/lib/proforma/helpers/export_helpers.rb
+++ b/lib/proforma/helpers/export_helpers.rb
@@ -49,7 +49,7 @@ module Proforma
 
       def meta_data(xml, meta_data)
         # underscore is used to disambiguate tag names from ruby methods
-        meta_data.each do |namespace, data|
+        meta_data&.each do |namespace, data|
           # if data.is_a? String
           #   data
           # end

--- a/lib/proforma/helpers/export_helpers.rb
+++ b/lib/proforma/helpers/export_helpers.rb
@@ -50,7 +50,7 @@ module Proforma
       end
 
       def meta_data(xml, meta_data)
-        meta_data&.each do |namespace, data|
+        meta_data.each do |namespace, data|
           inner_meta_data(xml, namespace, data)
         end
       end

--- a/lib/proforma/helpers/export_helpers.rb
+++ b/lib/proforma/helpers/export_helpers.rb
@@ -35,14 +35,14 @@ module Proforma
         end
       end
 
-      def inner_meta_data(xml, namespace, _key, data)
+      def inner_meta_data(xml, namespace, data)
         data.each do |key, value|
-          xml[namespace].send("#{key}_", data[key]) if value.is_a? String
+          xml[namespace].send("#{key}_", value) if value.is_a? String
 
           next unless value.is_a? Hash
 
           xml[namespace].send("#{key}_") do |meta_data_xml|
-            inner_meta_data(meta_data_xml, namespace, key, value)
+            inner_meta_data(meta_data_xml, namespace, value)
           end
         end
       end
@@ -50,12 +50,9 @@ module Proforma
       def meta_data(xml, meta_data)
         # underscore is used to disambiguate tag names from ruby methods
         meta_data&.each do |namespace, data|
-          # if data.is_a? String
-          #   data
-          # end
           data.each do |key, value|
-            xml[namespace].send("#{key}_", data[key]) if value.is_a? String
-            inner_meta_data(xml, namespace, key, value) if value.is_a? Hash
+            xml[namespace].send("#{key}_", value) if value.is_a? String
+            inner_meta_data(xml, namespace, value) if value.is_a? Hash
           end
         end
       end

--- a/lib/proforma/helpers/export_helpers.rb
+++ b/lib/proforma/helpers/export_helpers.rb
@@ -52,7 +52,12 @@ module Proforma
         meta_data&.each do |namespace, data|
           data.each do |key, value|
             xml[namespace].send("#{key}_", value) if value.is_a? String
-            inner_meta_data(xml, namespace, value) if value.is_a? Hash
+
+            next unless value.is_a? Hash
+
+            xml[namespace].send("#{key}_") do |meta_data_xml|
+              inner_meta_data(meta_data_xml, namespace, value)
+            end
           end
         end
       end

--- a/lib/proforma/helpers/export_helpers.rb
+++ b/lib/proforma/helpers/export_helpers.rb
@@ -37,12 +37,13 @@ module Proforma
 
       def inner_meta_data(xml, namespace, data)
         data.each do |key, value|
-          xml[namespace].send("#{key}_", value) if value.is_a? String
-
-          next unless value.is_a? Hash
-
-          xml[namespace].send("#{key}_") do |meta_data_xml|
-            inner_meta_data(meta_data_xml, namespace, value)
+          case value.class.name
+          when 'Hash'
+            xml[namespace].send("#{key}_") do |meta_data_xml|
+              inner_meta_data(meta_data_xml, namespace, value)
+            end
+          else
+            xml[namespace].send("#{key}_", value)
           end
         end
       end
@@ -50,15 +51,7 @@ module Proforma
       def meta_data(xml, meta_data)
         # underscore is used to disambiguate tag names from ruby methods
         meta_data&.each do |namespace, data|
-          data.each do |key, value|
-            xml[namespace].send("#{key}_", value) if value.is_a? String
-
-            next unless value.is_a? Hash
-
-            xml[namespace].send("#{key}_") do |meta_data_xml|
-              inner_meta_data(meta_data_xml, namespace, value)
-            end
-          end
+          inner_meta_data(xml, namespace, data)
         end
       end
 

--- a/lib/proforma/helpers/import_helpers.rb
+++ b/lib/proforma/helpers/import_helpers.rb
@@ -79,12 +79,12 @@ module Proforma
         {}.tap do |any_data|
           any_data_node.children.each do |node|
             key = (use_namespace ? node.namespace.prefix : any_data_node.name).to_sym
-            any_data[key.to_sym] = if node.node_type == Nokogiri::XML::Node::TEXT_NODE
-                                     node.text
-                                   else
-                                     # preserve any existing data in the nested hash
-                                     (any_data[key.to_sym] || {}).merge meta_data(node)
-                                   end
+            any_data[key] = if node.node_type == Nokogiri::XML::Node::TEXT_NODE
+                              node.text
+                            else
+                              # preserve any existing data in the nested hash
+                              (any_data[key] || {}).merge meta_data(node)
+                            end
           end
         end
       end

--- a/lib/proforma/helpers/import_helpers.rb
+++ b/lib/proforma/helpers/import_helpers.rb
@@ -94,10 +94,6 @@ module Proforma
             any_data[key.to_sym].merge! set_any_meta_data(node.name, node) if node.node_type == Nokogiri::XML::Node::ELEMENT_NODE
           end
         end
-
-
-        # meta_data[namespace.to_sym] = meta_data[namespace.to_sym] || {}
-        # meta_data[namespace.to_sym][key.to_sym] = value
       end
 
       private

--- a/lib/proforma/helpers/import_helpers.rb
+++ b/lib/proforma/helpers/import_helpers.rb
@@ -58,7 +58,7 @@ module Proforma
         test.files = test_files_from_test_configuration(test_configuration_node)
         test.configuration = extra_configuration_from_test_configuration(test_configuration_node)
         meta_data_node = test_node.xpath('xmlns:test-configuration').xpath('xmlns:test-meta-data')
-        test.meta_data = any_data_tag(meta_data_node.first) unless meta_data_node.blank?
+        test.meta_data = meta_data(meta_data_node) unless meta_data_node.blank?
       end
 
       def extra_configuration_from_test_configuration(test_configuration_node)
@@ -83,6 +83,25 @@ module Proforma
                          value: any_data_tag.children.first.text}
           end
         end
+      end
+
+      def meta_data(meta_data_node)
+        {}.tap do |any_data|
+          return any_data if meta_data_node.nil?
+
+          meta_data_node.children.each do |any_data_tag|
+            # create hash if not exists use existing if possible
+            set_any_meta_data(any_data, meta_data_node.children.first.namespace.prefix, any_data_tag.name, any_data_tag.children.first.text)
+            # any_data[meta_data_node.children.first.namespace.prefix.to_sym] = {any_data_tag.name.to_sym => any_data_tag.children.first.text}
+            # any_data << {namespace: meta_data_node.children.first.namespace.prefix, key: any_data_tag.name,
+            #              value: any_data_tag.children.first.text}
+          end
+        end
+      end
+
+      def set_any_meta_data(meta_data, namespace, key, value)
+        meta_data[namespace.to_sym] = meta_data[namespace.to_sym] || {}
+        meta_data[namespace.to_sym][key.to_sym] = value
       end
 
       private

--- a/lib/proforma/helpers/import_helpers.rb
+++ b/lib/proforma/helpers/import_helpers.rb
@@ -90,11 +90,7 @@ module Proforma
           return any_data if meta_data_node.nil?
 
           meta_data_node.children.each do |any_data_tag|
-            # create hash if not exists use existing if possible
             set_any_meta_data(any_data, meta_data_node.children.first.namespace.prefix, any_data_tag.name, any_data_tag.children.first.text)
-            # any_data[meta_data_node.children.first.namespace.prefix.to_sym] = {any_data_tag.name.to_sym => any_data_tag.children.first.text}
-            # any_data << {namespace: meta_data_node.children.first.namespace.prefix, key: any_data_tag.name,
-            #              value: any_data_tag.children.first.text}
           end
         end
       end

--- a/lib/proforma/models/task.rb
+++ b/lib/proforma/models/task.rb
@@ -16,6 +16,7 @@ module Proforma
       self.files = [] if files.nil?
       self.tests = [] if tests.nil?
       self.model_solutions = [] if model_solutions.nil?
+      self.meta_data = {} if meta_data.nil?
     end
 
     def all_files

--- a/lib/proforma/models/task.rb
+++ b/lib/proforma/models/task.rb
@@ -9,7 +9,7 @@ require 'proforma/errors'
 module Proforma
   class Task < Base
     attr_accessor :title, :description, :internal_description, :proglang, :uuid, :parent_uuid,
-                  :language, :model_solutions, :files, :tests
+                  :language, :model_solutions, :files, :tests, :meta_data
 
     def initialize(attributes = {})
       super

--- a/lib/proforma/services/exporter.rb
+++ b/lib/proforma/services/exporter.rb
@@ -50,14 +50,6 @@ module Proforma
       xml.send('meta-data') { meta_data(xml, @task.meta_data) }
     end
 
-    # def meta_data(xml)
-    #   test_meta_data xml, @task.meta_data
-    #   # @task.meta_data&.each do |namespace, data|
-    #   #   # underscore is used to disambiguate tag names from ruby methods
-    #   #   xml[entry[:namespace]].send("#{entry[:key]}_", entry.is_a?(Hash) ? (xml) : entry[:value])
-    #   # end
-    # end
-
     def add_objects_to_xml(xml)
       xml.files { files(xml) }
       xml.send('model-solutions') { model_solutions(xml) }

--- a/lib/proforma/services/exporter.rb
+++ b/lib/proforma/services/exporter.rb
@@ -47,8 +47,16 @@ module Proforma
     end
 
     def add_meta_data(xml)
-      xml.send('meta-data') {}
+      xml.send('meta-data') { meta_data(xml, @task.meta_data) }
     end
+
+    # def meta_data(xml)
+    #   test_meta_data xml, @task.meta_data
+    #   # @task.meta_data&.each do |namespace, data|
+    #   #   # underscore is used to disambiguate tag names from ruby methods
+    #   #   xml[entry[:namespace]].send("#{entry[:key]}_", entry.is_a?(Hash) ? (xml) : entry[:value])
+    #   # end
+    # end
 
     def add_objects_to_xml(xml)
       xml.files { files(xml) }

--- a/lib/proforma/services/importer.rb
+++ b/lib/proforma/services/importer.rb
@@ -83,7 +83,7 @@ module Proforma
 
     def set_meta_data
       meta_data_node = @task_node.xpath('xmlns:meta-data')
-      @task.meta_data = any_data_tag(meta_data_node.first) unless meta_data_node.blank?
+      @task.meta_data = meta_data(meta_data_node) if meta_data_node.text.present?
     end
 
     def add_model_solution(model_solution_node)

--- a/lib/proforma/services/importer.rb
+++ b/lib/proforma/services/importer.rb
@@ -43,6 +43,7 @@ module Proforma
       set_files
       set_model_solutions
       set_tests
+      set_meta_data
     end
 
     def set_namespaces
@@ -78,6 +79,11 @@ module Proforma
       @task_node.search('model-solutions//model-solution').each do |model_solution_node|
         add_model_solution model_solution_node
       end
+    end
+
+    def set_meta_data
+      meta_data_node = @task_node.xpath('xmlns:meta-data')
+      @task.meta_data = any_data_tag(meta_data_node.first) unless meta_data_node.blank?
     end
 
     def add_model_solution(model_solution_node)

--- a/lib/proforma/services/importer.rb
+++ b/lib/proforma/services/importer.rb
@@ -83,7 +83,7 @@ module Proforma
 
     def set_meta_data
       meta_data_node = @task_node.xpath('xmlns:meta-data')
-      @task.meta_data = meta_data(meta_data_node) if meta_data_node.text.present?
+      @task.meta_data = meta_data(meta_data_node, use_namespace: true) if meta_data_node.text.present?
     end
 
     def add_model_solution(model_solution_node)

--- a/lib/proforma/version.rb
+++ b/lib/proforma/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Proforma
-  VERSION = '0.6'
+  VERSION = '0.7'
 end

--- a/spec/custom_matchers/equal_task_spec.rb
+++ b/spec/custom_matchers/equal_task_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'equal_task matcher' do
     end
 
     context 'with a tiny change in the meta_data' do
-      before { task.meta_data[:namespace][:meta] = 'doto'}
+      before { task.meta_data[:namespace][:meta] = 'doto' }
 
       it 'fails' do
         expect(task).not_to be_an_equal_task_as task2

--- a/spec/custom_matchers/equal_task_spec.rb
+++ b/spec/custom_matchers/equal_task_spec.rb
@@ -48,6 +48,14 @@ RSpec.describe 'equal_task matcher' do
       end
     end
 
+    context 'with a tiny change in the nested meta_data' do
+      before { task.meta_data[:namespace][:nested][:test] = 'doto' }
+
+      it 'fails' do
+        expect(task).not_to be_an_equal_task_as task2
+      end
+    end
+
     context 'with a tiny change in a file' do
       before { task.files.first.content += 'a' }
 

--- a/spec/custom_matchers/equal_task_spec.rb
+++ b/spec/custom_matchers/equal_task_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'equal_task matcher' do
       expect(task).to be_an_equal_task_as task2
     end
 
-    context 'when both tasks have two equal exercises, but are still different' do
+    context 'when both tasks have two equal files, but are still different' do
       let(:files_3_id) { 2 }
       let(:files2_3_id) { 1 }
 

--- a/spec/custom_matchers/equal_task_spec.rb
+++ b/spec/custom_matchers/equal_task_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe 'equal_task matcher' do
     end
   end
 
+  context 'when only one task has a file' do
+    let(:task2) { build(:task, files: [build(:task_file)]) }
+
+    it 'fails the comparison' do
+      expect(task).not_to be_an_equal_task_as task2
+    end
+  end
+
   context 'when the tasks are complex' do
     let(:task) { build(:task, :with_everything) }
     let(:task2) { build(:task, :with_everything) }

--- a/spec/custom_matchers/equal_task_spec.rb
+++ b/spec/custom_matchers/equal_task_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe 'equal_task matcher' do
       expect(task).to be_an_equal_task_as task2
     end
 
+    context 'with a tiny change in the meta_data' do
+      before { task.meta_data[:namespace][:meta] = 'doto'}
+
+      it 'fails' do
+        expect(task).not_to be_an_equal_task_as task2
+      end
+    end
+
     context 'with a tiny change in a file' do
       before { task.files.first.content += 'a' }
 
@@ -58,6 +66,14 @@ RSpec.describe 'equal_task matcher' do
 
     context 'with a tiny change in a test' do
       before { task.tests.first.title += 'a' }
+
+      it 'fails' do
+        expect(task).not_to be_an_equal_task_as task2
+      end
+    end
+
+    context 'with a tiny change in a test meta_data' do
+      before { task.tests.first.meta_data[:test_meta] = 'diti' }
 
       it 'fails' do
         expect(task).not_to be_an_equal_task_as task2

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
     trait(:with_embedded_bin_file) { files { build_list(:task_file, 1, :populated, :small_content, :binary) } }
     trait(:with_attached_txt_file) { files { build_list(:task_file, 1, :populated, :large_content, :text) } }
     trait(:with_attached_bin_file) { files { build_list(:task_file, 1, :populated, :large_content, :binary) } }
-    trait(:with_meta_data) { meta_data { {namespace: {meta: 'data', test: 'data'}} } }
+    trait(:with_meta_data) { meta_data { {namespace: {meta: 'data', nested: {test: {abc: '123'}, foo: 'bar'}}} } }
 
     trait(:with_model_solution) { model_solutions { build_list(:model_solution, 1, :populated) } }
     trait(:with_test) { tests { build_list(:test, 1, :populated) } }

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
     trait(:with_embedded_bin_file) { files { build_list(:task_file, 1, :populated, :small_content, :binary) } }
     trait(:with_attached_txt_file) { files { build_list(:task_file, 1, :populated, :large_content, :text) } }
     trait(:with_attached_bin_file) { files { build_list(:task_file, 1, :populated, :large_content, :binary) } }
+    trait(:with_meta_data)  { meta_data { {namespace: {meta: 'data', test: 'data'}} } }
 
     trait(:with_model_solution) { model_solutions { build_list(:model_solution, 1, :populated) } }
     trait(:with_test) { tests { build_list(:test, 1, :populated) } }
@@ -26,7 +27,9 @@ FactoryBot.define do
       with_multiple_embedded_txt_files
       with_model_solution
       with_test_with_meta_data
+      with_meta_data
     end
+
 
     trait(:invalid) { files { build_list(:task_file, 1, :invalid) } }
   end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
     trait(:with_embedded_bin_file) { files { build_list(:task_file, 1, :populated, :small_content, :binary) } }
     trait(:with_attached_txt_file) { files { build_list(:task_file, 1, :populated, :large_content, :text) } }
     trait(:with_attached_bin_file) { files { build_list(:task_file, 1, :populated, :large_content, :binary) } }
-    trait(:with_meta_data)  { meta_data { {namespace: {meta: 'data', test: 'data'}} } }
+    trait(:with_meta_data) { meta_data { {namespace: {meta: 'data', test: 'data'}} } }
 
     trait(:with_model_solution) { model_solutions { build_list(:model_solution, 1, :populated) } }
     trait(:with_test) { tests { build_list(:test, 1, :populated) } }
@@ -29,7 +29,6 @@ FactoryBot.define do
       with_test_with_meta_data
       with_meta_data
     end
-
 
     trait(:invalid) { files { build_list(:task_file, 1, :invalid) } }
   end

--- a/spec/factories/test.rb
+++ b/spec/factories/test.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
     end
 
     trait(:with_meta_data) do
-      meta_data { [{namespace: 'test', key: 'meta', value: 'data'}] }
+      meta_data { {namespace: {test_meta: 'data', test: 'test_data'}} }
     end
 
     trait(:with_multiple_files) do

--- a/spec/proforma/exporter_spec.rb
+++ b/spec/proforma/exporter_spec.rb
@@ -280,9 +280,9 @@ RSpec.describe Proforma::Exporter do
       end
 
       context 'when test has meta-data' do
+        let(:custom_namespaces) { [{prefix: 'namespace', uri: 'custom_namespace.org'}] }
         let(:task) do
-          build(:task, :populated, tests: build_list(:test, 1, meta_data: [{namespace: 'test', key: 'test', value: 'data'},
-                                                                           {namespace: 'test', key: 'meta', value: 'data'}]))
+          build(:task, :populated, tests: build_list(:test, 1, meta_data: {namespace: {meta: 'data', test: 'data'}}))
         end
         let(:meta_data_node) { doc.xpath('/xmlns:task/xmlns:tests/xmlns:test/xmlns:test-configuration/xmlns:test-meta-data') }
 
@@ -297,11 +297,11 @@ RSpec.describe Proforma::Exporter do
         end
 
         it 'adds test node with correct namespace to test-meta-data node' do
-          expect(meta_data_node.xpath('test:test').text).to eql 'data'
+          expect(meta_data_node.xpath('namespace:test').text).to eql 'data'
         end
 
         it 'adds meta node with correct namespace to test-meta-data node' do
-          expect(meta_data_node.xpath('test:meta').text).to eql 'data'
+          expect(meta_data_node.xpath('namespace:meta').text).to eql 'data'
         end
       end
 

--- a/spec/proforma/importer_spec.rb
+++ b/spec/proforma/importer_spec.rb
@@ -81,6 +81,15 @@ RSpec.describe Proforma::Importer do
       end
     end
 
+    context 'when task has meta-data' do
+      let(:export_namespaces) { [{prefix: 'namespace', uri: 'custom_namespace.org'}] }
+      let(:task) { build(:task, meta_data: {namespace: {meta: 'data', nested: {test: {abc: '123'}, foo: 'bar'}}}) }
+
+      it 'successfully imports the task' do
+        expect(imported_task).to be_an_equal_task_as ref_task
+      end
+    end
+
     context 'when task has an embedded text file' do
       let(:task) { build(:task, :with_embedded_txt_file) }
 
@@ -143,7 +152,9 @@ RSpec.describe Proforma::Importer do
 
       context 'when test has meta-data' do
         let(:export_namespaces) { [{prefix: 'namespace', uri: 'custom_namespace.org'}] }
-        let(:task) { build(:task, tests: build_list(:test, 1, meta_data: {namespace: {meta: 'data', test: 'data'}})) }
+        let(:task) do
+          build(:task, tests: build_list(:test, 1, meta_data: {namespace: {meta: 'data', nested: {test: {abc: '123'}, foo: 'bar'}}}))
+        end
 
         it 'successfully imports the task' do
           expect(imported_task).to be_an_equal_task_as ref_task

--- a/spec/proforma/importer_spec.rb
+++ b/spec/proforma/importer_spec.rb
@@ -142,7 +142,8 @@ RSpec.describe Proforma::Importer do
       end
 
       context 'when test has meta-data' do
-        let(:task) { build(:task, tests: build_list(:test, 1, :with_meta_data)) }
+        let(:export_namespaces) { [{prefix: 'namespace', uri: 'custom_namespace.org'}] }
+        let(:task) { build(:task, tests: build_list(:test, 1, meta_data: {namespace: {meta: 'data', test: 'data'}})) }
 
         it 'successfully imports the task' do
           expect(imported_task).to be_an_equal_task_as ref_task

--- a/spec/proforma/importer_spec.rb
+++ b/spec/proforma/importer_spec.rb
@@ -81,6 +81,14 @@ RSpec.describe Proforma::Importer do
       end
     end
 
+    context 'when task has no meta-data' do
+      let(:task) { build(:task, meta_data: {}) }
+
+      it 'successfully imports the task' do
+        expect(imported_task).to be_an_equal_task_as ref_task
+      end
+    end
+
     context 'when task has meta-data' do
       let(:export_namespaces) { [{prefix: 'namespace', uri: 'custom_namespace.org'}] }
       let(:task) { build(:task, meta_data: {namespace: {meta: 'data', nested: {test: {abc: '123'}, foo: 'bar'}}}) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 
 require 'simplecov'
 SimpleCov.start do
-  # enable_coverage :branch
+  enable_coverage :branch
 end
 
 require 'bundler/setup'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 
 require 'simplecov'
 SimpleCov.start do
-  enable_coverage :branch
+  # enable_coverage :branch
 end
 
 require 'bundler/setup'


### PR DESCRIPTION
- add support for generic meta_data node on task level
  - make use of custom_namespace
  - use a nested hash in ruby as representation