### PR TITLE
Tighten Ruby requirement to allow Ruby 3.x versions

### DIFF
--- a/proforma.gemspec
+++ b/proforma.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/openHPI/proforma'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = '~> 2.6'
+  spec.required_ruby_version = '>= 2.6'
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   # if spec.respond_to?(:metadata)


### PR DESCRIPTION
I started using a newer Ruby version for my local dev environment. A major issue I faced was with our proforma gem not allowing the usage of Ruby 3 and above. The previous requirement `'~> 2.6'` allowed `'>= 2.6', '< 3'`. With this new requirement string, the Ruby 3.x is supported. All tests passed when running those locally.

Once we merged this, a new version would be great to allow an update in CodeHarbor and CodeOcean (together with the other work-in-progress changes).