### PR TITLE
Update gemspec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.1
           bundler-cache: true
 
       - name: Run tests
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.1
           bundler-cache: true
 
       - name: Run rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,22 @@
 PATH
   remote: .
   specs:
-    proforma (0.7)
+    proforma (0.7.1)
       activemodel (>= 5.2.3, < 8.0.0)
-      activesupport (>= 5.2.3, < 7.0.0)
+      activesupport (>= 5.2.3, < 8.0.0)
       nokogiri (>= 1.10.2, < 2.0.0)
       rubyzip (>= 1.2.2, < 3.0.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.4.4)
-      activesupport (= 6.1.4.4)
-    activesupport (6.1.4.4)
+    activemodel (7.0.0)
+      activesupport (= 7.0.0)
+    activesupport (7.0.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     ast (2.4.2)
     byebug (11.1.3)
     coderay (1.1.3)
@@ -112,11 +111,10 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.3)
-    thor (1.1.0)
+    thor (1.2.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
-    zeitwerk (2.5.3)
 
 PLATFORMS
   ruby

--- a/lib/proforma/version.rb
+++ b/lib/proforma/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Proforma
-  VERSION = '0.7'
+  VERSION = '0.7.1'
 end

--- a/proforma.gemspec
+++ b/proforma.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/openHPI/proforma'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = '~> 2.6'
+  spec.required_ruby_version = '>= 2.6'
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   # if spec.respond_to?(:metadata)

--- a/proforma.gemspec
+++ b/proforma.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activemodel', '>= 5.2.3', '< 8.0.0'
-  spec.add_dependency 'activesupport', '>= 5.2.3', '< 7.0.0'
+  spec.add_dependency 'activesupport', '>= 5.2.3', '< 8.0.0'
   spec.add_dependency 'nokogiri', '>= 1.10.2', '< 2.0.0'
   spec.add_dependency 'rubyzip', '>= 1.2.2', '< 3.0.0'
 


### PR DESCRIPTION
based on #199, this PR updates the gemspec to allow for Rails 7 and the CI to test with Ruby 3.1
It also bumps the version to 0.7.1